### PR TITLE
Fix #28: correct width for wide columns

### DIFF
--- a/beautifultable/beautifultable.py
+++ b/beautifultable/beautifultable.py
@@ -622,7 +622,8 @@ class BeautifulTable(object):
         actual_space = sum_ - temp_sum
         for i, _ in enumerate(widths):
             if not flag[i]:
-                widths[i] = int(round(widths[i] * avail_space / actual_space))
+                new_width = int(round(widths[i] * avail_space / actual_space))
+                widths[i] = min(widths[i], new_width)
         self.column_widths = widths
 
     def set_padding_widths(self, pad_width):

--- a/test.py
+++ b/test.py
@@ -371,6 +371,18 @@ class TableOperationsTestCase(unittest.TestCase):
         width = self.table.get_table_width()
         self.assertEqual(width, 0)
 
+    def test_table_auto_width(self):
+        row_list = ['abcdefghijklmopqrstuvwxyz', 1234, 'none']
+
+        self.create_table(200)
+        self.table.append_row(row_list)
+        len_for_max_width_200 = len(str(self.table))
+
+        self.create_table(80)
+        self.table.append_row(row_list)
+        len_for_max_width_80 = len(str(self.table))
+
+        self.assertEqual(len_for_max_width_80, len_for_max_width_200)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This should fix the bug that wide columns receive all the remaining width from `max_width` described in issue #28. I am not sure why the columns are first flagged and than adjusted if their width exceeds the "fair share" of `max_width", so I left that code in. Maybe it's not needed and this could be solved by removing the lines but I suppose note.

I also added a test to check if a table with a large `max_width` gives the same string length as table with a small (but sufficient) `max_width`.