### PR TITLE
skip multi release on pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ script:
 
 deploy:
   provider: pypi
+  skip_existing: true
   distributions: sdist bdist_wheel
   user: pri22296
   password:
@@ -44,5 +45,3 @@ deploy:
   on:
     tags: true
     repo: pri22296/beautifultable
-    branch: master
-    python: '3.6'


### PR DESCRIPTION
Signed-off-by: Nikhil Dhandre <nik.digitronik@live.com>

- It will skip if release already available with same version
- No need to point master tagging will take care of it. 

fix #72 