### PR TITLE
#70 - Allow import and export from CSV file

### DIFF
--- a/beautifultable/beautifultable.py
+++ b/beautifultable/beautifultable.py
@@ -28,6 +28,7 @@ Example
 from __future__ import division, unicode_literals
 
 import copy
+import csv
 import operator
 
 from . import enums
@@ -1415,3 +1416,73 @@ class BeautifulTable(object):
             string_.append(line)
 
         return "\n".join(string_)
+
+    def to_csv(self, file_name, delimiter=','):
+        """Export table to CSV format.
+
+        Parameters
+        ----------
+        file_name : str
+            Path to CSV file which BeautifulTable will write to.
+
+        delimiter : str, optional
+            Delimiter used as value separator. Defaults to comma (',').
+        """
+
+        if not isinstance(file_name, str):
+            raise ValueError(
+                (
+                    "Expected 'file_name' to be string, got {}"
+                ).format(type(file_name).__name__)
+            )
+
+        try:
+            with open(file_name, mode='wt', newline='') as csv_file:
+                csv_writer = csv.writer(csv_file,
+                                        delimiter=delimiter,
+                                        quoting=csv.QUOTE_MINIMAL)
+                csv_writer.writerow(self.column_headers)  # write header
+                csv_writer.writerows(self._table)  # write table
+        except OSError:
+            raise
+
+    def from_csv(self, file_name, delimiter=',', header_exists=True):
+        """Create table from CSV file.
+
+        Parameters
+        ----------
+        file_name : str
+            Path to CSV file which `BeautifulTable` will read from.
+        delimiter : str, optional
+            Delimiter used as value separator. Defaults to comma (`,`).
+        header_exists : bool, optional
+            First row in CSV file should be set as table header.
+
+        Raises
+        ------
+        ValueError
+            If `file_name` is not str type.
+        FileNotFoundError
+            If `file_name` is not valid path to file.
+        """
+
+        if not isinstance(file_name, str):
+            raise ValueError(
+                (
+                    "Expected 'file_name' to be string, got {}"
+                ).format(type(file_name).__name__)
+            )
+
+        try:
+            with open(file_name, mode='rt', newline='') as csv_file:
+                csv_file = csv.reader(csv_file, delimiter=delimiter)
+
+                if header_exists:
+                    self.column_headers = next(csv_file)
+
+                for row in csv_file:
+                    self.append_row(row)
+
+                return self
+        except FileNotFoundError:
+            raise

--- a/test.py
+++ b/test.py
@@ -2,6 +2,8 @@
 
 
 import unittest
+import os
+
 from beautifultable import BeautifulTable
 
 
@@ -514,6 +516,45 @@ class TableOperationsTestCase(unittest.TestCase):
         len_for_max_width_80 = len(str(self.table))
 
         self.assertEqual(len_for_max_width_80, len_for_max_width_200)
+
+    def test_csv_export(self):
+        # Create csv files in path.
+        self.table.to_csv('beautiful_table.csv')
+        self.table.to_csv('./docs/beautiful_table.csv')
+
+        with self.assertRaises(ValueError):
+            self.table.to_csv(1)
+
+        # Check if csv files exist.
+        self.assertTrue(os.path.exists('beautiful_table.csv'))
+        self.assertTrue(os.path.exists('./docs/beautiful_table.csv'))
+
+        # Teardown step.
+        os.remove('beautiful_table.csv')
+        os.remove('./docs/beautiful_table.csv')
+
+    def test_csv_import(self):
+        # Export table as CSV file and import it back.
+        self.table.to_csv('beautiful_table.csv')
+
+        test_table = BeautifulTable()
+        test_table.from_csv('beautiful_table.csv')
+
+        with self.assertRaises(ValueError):
+            self.table.from_csv(1)
+
+        self.assertEqual(len(self.table), len(test_table))
+        self.assertEqual(self.table.column_headers, test_table.column_headers)
+
+        # for index in range(len(self.table)):
+        #     self.assertEqual(self.table[index], test_table[index])
+
+        test_table = BeautifulTable()
+        test_table.from_csv('beautiful_table.csv', header_exists=False)
+        self.assertEqual(len(self.table), len(test_table) - 1)
+
+        # Teardown step.
+        os.remove('beautiful_table.csv')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I added a feature to `BeautifulTable` for exporting and importing from CSV file. Docstrings are also written and it's covered with tests.

`to_csv` method exports to CSV file defined with `file_path`.
`from_csv` method imports CSV file from `file_path`.
Both methods also use `delimiter` parameter to define how elements will be delimited; for example with `\t` or `,` .

Lastly, there's a `_convert_row` method which parses properly rows read from CSV file. When row is read from file, everything gets converted to string type, even integers and floats. This keeps floats and integers from converting to string.
Example:
```
>>> print(self._convert_row(["Jacob", "1", "boy"]))
["Jacob", 1, "boy"]
 >>> print(self._convert_row(["Isabella", "1.7", "girl"]))
["Isabella", 1.7, "girl"]
```

---

**NOTE**: Method `from_csv` can be decorated with `classmethod` decorator since it doesn't use `self`. We generally use class method to create factory methods. Factory methods return class object ( similar to a constructor ) for different use cases. [REFERENCE](https://www.geeksforgeeks.org/class-method-vs-static-method-python/)