### PR TITLE
62 - Create import and export from json file

### DIFF
--- a/test.py
+++ b/test.py
@@ -567,6 +567,61 @@ class TableOperationsTestCase(unittest.TestCase):
         # Teardown step.
         os.remove('beautiful_table.csv')
 
+    def test_json_export(self):
+        self.table.to_json('beautiful_table_1.json', None, False)
+        self.table.to_json('beautiful_table_2.json', 2)
+        self.table.to_json('beautiful_table_3.json', 4)
+        self.table.to_json('beautiful_table_4.json', 0)
+        self.table.to_json('beautiful_table_5.json', 4, True)
+
+        with self.assertRaises(ValueError):
+            self.table.to_json(1)
+
+        # Check if json files exist.
+        self.assertTrue(os.path.exists('beautiful_table_1.json'))
+        self.assertTrue(os.path.exists('beautiful_table_2.json'))
+        self.assertTrue(os.path.exists('beautiful_table_3.json'))
+        self.assertTrue(os.path.exists('beautiful_table_4.json'))
+        self.assertTrue(os.path.exists('beautiful_table_5.json'))
+
+        # Teardown step.
+        os.remove('beautiful_table_1.json')
+        os.remove('beautiful_table_2.json')
+        os.remove('beautiful_table_3.json')
+        os.remove('beautiful_table_4.json')
+        os.remove('beautiful_table_5.json')
+
+    def test_json_import(self):
+        self.table.to_json('beautiful_table_1.json', None, False)
+        self.table.to_json('beautiful_table_2.json', 4, False)
+
+        with self.assertRaises(ValueError):
+            self.table.from_json(1)
+
+        table_with_empty_header = BeautifulTable()
+        table_with_empty_header.append_row(["Jacob", 1, "boy"])
+        table_with_empty_header.append_row(["Isabella", 1, "girl"])
+
+        with self.assertRaises(ValueError):
+            table_with_empty_header.to_json('beautiful_table_empty.json')
+
+        table_1 = self.table.from_json('beautiful_table_1.json')
+        table_2 = self.table.from_json('beautiful_table_2.json')
+
+        self.assertEqual(len(self.table), len(table_1))
+        self.assertEqual(len(self.table), len(table_2))
+
+        self.assertEqual(self.table.column_headers, table_1.column_headers)
+        self.assertEqual(self.table.column_headers, table_2.column_headers)
+
+        for index in range(len(self.table)):
+            self.assertEqual(self.table[index], table_1[index])
+            self.assertEqual(self.table[index], table_2[index])
+
+        # Teardown step.
+        os.remove('beautiful_table_1.json')
+        os.remove('beautiful_table_2.json')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I have created import and export to json file #62 . I have also included thorough testing for functionality.

Exporting to json supports several configuration that comply with `json.dump` function.

Example:

```
table = BeautifulTable(max_width)
table.column_headers = ["name", "rank", "gender"]
table.append_row(["Jacob", 1, "boy"])
table.append_row(["Isabella", 1, "girl"])
table.append_row(["Ethan", 2, "boy"])
table.append_row(["Sophia", 2, "girl"])
table.append_row(["Michael", 3, "boy"])
```

JSON file:

```
[
    {
        "name": "Jacob",
        "rank": 1,
        "gender": "boy"
    },
    {
        "name": "Isabella",
        "rank": 1,
        "gender": "girl"
    },
    {
        "name": "Ethan",
        "rank": 2,
        "gender": "boy"
    },
    {
        "name": "Sophia",
        "rank": 2,
        "gender": "girl"
    },
    {
        "name": "Michael",
        "rank": 3,
        "gender": "boy"
    }
]
```

---

Some things to note:
- This functionality doesn't support exporting Subtables. (_Can be added if needed_)
- `table.column_headers` should not contain empty names, since JSON is name/value pairs of data.
- `to_json` method receives `indent` argument which is equivalent to argument `indent` of `json.dump`. I'm not completely sure how to state that this parameter can be `int` or `str` or `None` in _Numpy docstring_. Check indent argument at https://docs.python.org/3.7/library/json.html#json.dump .

If you need me to expand, improve or reduce functionality, I'm happy to comply with guidelines. 